### PR TITLE
Update the Locate query to use the production URL

### DIFF
--- a/src/pt.js
+++ b/src/pt.js
@@ -74,7 +74,7 @@
       // If no server was specified then use a loadbalancer. If no loadbalancer
       // is specified, use the locate service from Measurement Lab.
       // TODO(cristinaleon): Change the URL once the daemonset is deployed in production.
-      const lbURL = (config && ('loadbalancer' in config)) ? new URL(config.loadbalancer) : new URL('https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/pt/ndt7');
+      const lbURL = (config && ('loadbalancer' in config)) ? new URL(config.loadbalancer) : new URL('https://locate.measurementlab.net/v2/nearest/pt/ndt7');
       lbURL.search = metadata;
       callbacks.serverDiscovery({loadbalancer: lbURL});
       const response = await fetch(lbURL).catch((err) => {

--- a/src/pt.js
+++ b/src/pt.js
@@ -73,7 +73,6 @@
 
       // If no server was specified then use a loadbalancer. If no loadbalancer
       // is specified, use the locate service from Measurement Lab.
-      // TODO(cristinaleon): Change the URL once the daemonset is deployed in production.
       const lbURL = (config && ('loadbalancer' in config)) ? new URL(config.loadbalancer) : new URL('https://locate.measurementlab.net/v2/nearest/pt/ndt7');
       lbURL.search = metadata;
       callbacks.serverDiscovery({loadbalancer: lbURL});


### PR DESCRIPTION
I verified that the data from this client is successfully loaded to `mlab-oti.raw_pt.ndt7`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test-js/5)
<!-- Reviewable:end -->
