### PR TITLE
Remove reference to second job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@m-lab/packet-test",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "main": "src/pt.js",
   "scripts": {


### PR DESCRIPTION
This PR removes the "[needs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds)" reference to a 2nd job from the publish workflow, which is causing it to [fail](https://github.com/m-lab/packet-test-js/actions/runs/10463598495).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test-js/7)
<!-- Reviewable:end -->
