### PR TITLE
Install minify in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,7 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [created]
+  - push
 
 jobs:
   publish-npm:
@@ -16,6 +15,7 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+      - run: npm i minify
       - run: npm ci
       - run: npm publish
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@
 name: Node.js Package
 
 on:
-  - push
+  release:
+    types: [created]
 
 jobs:
   publish-npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@m-lab/packet-test",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "src/pt.js",
   "scripts": {


### PR DESCRIPTION
This PR installs `minify` in the publish workflow. I tested the workflow with a ["push" trigger](https://github.com/m-lab/packet-test-js/commit/6710aa056b709fd97a9072de9439fd80175c6bc4) ([successful job](https://github.com/m-lab/packet-test-js/actions/runs/10474725905)) and verified that the package was published to npm.

![image](https://github.com/user-attachments/assets/177209a8-7bf0-46fe-adcd-d05d792d57a9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test-js/8)
<!-- Reviewable:end -->
