### PR TITLE
Use uglifyjs instead of minify

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@
 name: Node.js Package
 
 on:
-  - push
+  release:
+    types: [created]
 
 jobs:
   publish-npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@m-lab/packet-test",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m-lab/packet-test",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "main": "src/pt.js",
   "scripts": {


### PR DESCRIPTION
This PR substitutes the [`minify`](https://www.npmjs.com/package/minify) command for [`uglify-js`](https://www.npmjs.com/package/uglify-js) to compress files. The `minify` command has had some issues with switching up the ordering and breaking JS code, which I have seen myself (`ReferenceError: Cannot access 'h' before initialization`) when loading the compressed files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test-js/9)
<!-- Reviewable:end -->
